### PR TITLE
feat: add QR code generation and printing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ It is built upon the core protocol and communication logic of the kitty-printer 
 
 - **Text Printing**: Print text with configurable font size
 - **Image Printing**: Print PNG, JPG, and other image formats
+- **QR Code Printing**: Generate and print QR codes from text or URLs
 - **File Support**: Print from text files
 - **Bluetooth Discovery**: Scan for compatible thermal printers
 - **Compatible Protocol**: Uses the same protocol as kitty-printer web project
@@ -187,6 +188,18 @@ Print contents of a text file:
 python3 thermy.py --file document.txt --device AA:BB:CC:DD:EE:FF
 ```
 
+### Print QR Code
+
+Generate and print a QR code from text or a URL:
+
+```bash
+# Print a QR code for a URL
+python3 thermy.py --qr "https://example.com" --device AA:BB:CC:DD:EE:FF
+
+# Print a QR code for plain text
+python3 thermy.py --qr "Hello, scan me!" --device AA:BB:CC:DD:EE:FF
+```
+
 ### Print Image
 
 Print an image file (PNG, JPG, etc.):
@@ -220,6 +233,7 @@ Options:
   --text TEXT, -t TEXT          Text to print
   --file FILE, -f FILE          Text file to print
   --image IMAGE, -i IMAGE       Image file to print
+  --qr TEXT                     Generate and print a QR code from text/URL
   --device ADDRESS, -d ADDRESS  Bluetooth device address
   --font-size SIZE             Font size for text (default: 16)
   --align {left,center,right}  Text alignment (default: center)
@@ -247,6 +261,9 @@ python3 thermy.py --file receipt.txt --device AA:BB:CC:DD:EE:FF
 
 # Print an image
 python3 thermy.py --image logo.png --device AA:BB:CC:DD:EE:FF
+
+# Print a QR code
+python3 thermy.py --qr "https://example.com" --device AA:BB:CC:DD:EE:FF
 ```
 
 ### Advanced Usage
@@ -269,6 +286,9 @@ python3 thermy.py --text "DANGER\nHIGH VOLTAGE" --border 5 --invert --font-size 
 
 # Simple framed receipt header
 python3 thermy.py --text "RECEIPT" --border 3 --align center --font-size 20 --device AA:BB:CC:DD:EE:FF
+
+# QR code for WiFi sharing
+python3 thermy.py --qr "WIFI:T:WPA;S:MyNetwork;P:MyPassword;;" --device AA:BB:CC:DD:EE:FF
 
 # High quality image (slower)
 python3 thermy.py --image photo.jpg --speed 20 --energy 10000 --device AA:BB:CC:DD:EE:FF
@@ -308,6 +328,9 @@ python3 thermy.py --text "Text Test - Hello World!" --device AA:BB:CC:DD:EE:FF
 # Test file printing
 echo "File test content" > test.txt
 python3 thermy.py --file test.txt --device AA:BB:CC:DD:EE:FF
+
+# Test QR code printing
+python3 thermy.py --qr "https://example.com" --device AA:BB:CC:DD:EE:FF
 
 # Test image printing (create a small test image first)
 python3 thermy.py --image test_image.png --device AA:BB:CC:DD:EE:FF
@@ -426,6 +449,7 @@ The script is designed for compatibility with:
 - **Python**: 3.11+ (as available on Debian 12)
 - **bleak**: 0.21.1+ (Bluetooth Low Energy)
 - **Pillow**: 10.0.0+ (Image processing)
+- **qrcode**: 7.4+ (QR code generation)
 
 These versions are tested to work reliably on Debian 12 (Orange Pi) systems.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ bleak>=0.21.1
 
 # Image processing and manipulation
 Pillow>=10.0.0
+
+# QR code generation
+qrcode>=7.4

--- a/thermy.py
+++ b/thermy.py
@@ -23,6 +23,12 @@ except ImportError:
     BleakDBusError = Exception
     BleakError = Exception
 
+try:
+    import qrcode
+    QRCODE_AVAILABLE = True
+except ImportError:
+    QRCODE_AVAILABLE = False
+
 
 class CatProtocol:
     """Python implementation of cat-protocol.ts for thermal printer communication"""
@@ -793,6 +799,66 @@ class ThermalPrinterCLI:
         print("Image printed successfully!")
         return True
 
+    def generate_qr(self, data: str, box_size: int = 8) -> Image.Image:
+        """Generate a QR code image from data string"""
+        if not QRCODE_AVAILABLE:
+            raise RuntimeError("QR code support not available. Install with: pip install qrcode")
+
+        qr = qrcode.QRCode(
+            version=None,  # Auto-detect size
+            error_correction=qrcode.constants.ERROR_CORRECT_M,
+            box_size=box_size,
+            border=4,
+        )
+        qr.add_data(data)
+        qr.make(fit=True)
+
+        img = qr.make_image(fill_color="black", back_color="white").convert('RGB')
+
+        # Resize to fit paper width while maintaining aspect ratio
+        if img.width > self.paper_width:
+            scale = self.paper_width / img.width
+            img = img.resize((self.paper_width, int(img.height * scale)))
+        elif img.width < self.paper_width:
+            # Center on paper-width canvas
+            padded = Image.new("RGB", (self.paper_width, img.height), (255, 255, 255))
+            padded.paste(img, ((self.paper_width - img.width) // 2, 0))
+            img = padded
+
+        print(f"Generated QR code: {img.width}x{img.height}")
+        return img.convert('RGBA')
+
+    async def print_qr(self, data: str, speed: int = 45, energy: int = 8000) -> bool:
+        """Generate and print a QR code"""
+        if not self.printer:
+            print("Error: Printer not connected")
+            return False
+
+        print(f"Generating QR code for: {data}")
+        try:
+            bitmap = self.generate_qr(data)
+        except Exception as e:
+            print(f"Error generating QR code: {e}")
+            return False
+
+        print("Converting QR code to print data...")
+        lines = self.bitmap_to_print_data(bitmap, is_image=True)
+
+        print("Preparing printer...")
+        await self.printer.prepare(speed, energy)
+
+        print(f"Sending {len(lines)} lines to printer...")
+        for i, line in enumerate(lines):
+            await self.printer.draw(line)
+            if i % 50 == 0:
+                print(f"Progress: {i+1}/{len(lines)}")
+
+        print("Finishing print job...")
+        await self.printer.finish(50)
+
+        print("QR code printed successfully!")
+        return True
+
 
 def check_requirements():
     """Check if system requirements are met"""
@@ -815,6 +881,7 @@ async def main():
     parser.add_argument('--text', '-t', help='Text to print')
     parser.add_argument('--file', '-f', help='Text file to print')
     parser.add_argument('--image', '-i', help='Image file to print (PNG, JPG, etc.)')
+    parser.add_argument('--qr', help='Generate and print a QR code from text/URL')
     parser.add_argument('--device', '-d', help='Bluetooth device address')
     parser.add_argument('--font-size', type=int, default=16, help='Font size for text (default: 16)')
     parser.add_argument('--align', choices=['left', 'center', 'right'], default='center', help='Text alignment (default: center)')
@@ -891,16 +958,19 @@ async def main():
                     print(f"Error reading file {args.file}: {e}")
             else:
                 print(f"❌ File not found: {args.file}")
+        elif args.qr:
+            success = await printer_cli.print_qr(args.qr, args.speed, args.energy)
         elif args.image:
             success = await printer_cli.print_image(args.image, args.speed, args.energy)
         else:
-            print("❌ No content specified. Use --text, --file, or --image")
+            print("❌ No content specified. Use --text, --file, --image, or --qr")
             print("\nExamples:")
             print('  python3 thermy.py --text "Hello World" --device AA:BB:CC:DD:EE:FF')
             print('  python3 thermy.py --text "Left\\nAligned" --align left --device AA:BB:CC:DD:EE:FF')
             print('  python3 thermy.py --text "IMPORTANT" --invert --border 2 --font-size 24 --device AA:BB:CC:DD:EE:FF')
             print('  python3 thermy.py --text "WARNING" --border 3 --align center --device AA:BB:CC:DD:EE:FF')
             print('  python3 thermy.py --file document.txt --align center --border 1 --device AA:BB:CC:DD:EE:FF')
+            print('  python3 thermy.py --qr "https://example.com" --device AA:BB:CC:DD:EE:FF')
             print('  python3 thermy.py --image photo.jpg --device AA:BB:CC:DD:EE:FF')
         
         if success:


### PR DESCRIPTION
## Summary
- Add `--qr` flag to generate and print QR codes directly from text or URLs
- Uses the `qrcode` Python library with auto-sizing and medium error correction
- QR code is centered on the thermal paper width (384px)

## Test plan
- [x] Verify `pip install qrcode` installs correctly from updated requirements.txt
- [x] Test `--qr "https://example.com"` generates and prints a scannable QR code
- [x] Test with long URLs and short text to verify auto-sizing

🤖 Generated with [Claude Code](https://claude.com/claude-code)